### PR TITLE
Syntax error in http://popcornjs.org/popcorn-docs/parsers/#JSON%20parser

### DIFF
--- a/parsers/_posts/2012-12-12-parserJSON.md
+++ b/parsers/_posts/2012-12-12-parserJSON.md
@@ -27,13 +27,17 @@ Parses a JSON file:
     <html>
       <head>
         <script src="popcorn-complete.js"></script>
-        <script type="text/javascript">
+         <script type="text/javascript">
 
-          var popcorn( "#video" );
+         document.addEventListener('DOMContentLoaded', function () {
 
-          popcorn.parseJSON( "data/data.json", function() {
+            var p = Popcorn("#video");
+
+            p.parseJSON( "data/data.json", function() {
             alert( "JSON Parsed Successfully" );
-          });
+            });
+
+         }, false);
 
         </script>
       </head>


### PR DESCRIPTION
Updated pull request.
Wrong syntax:

var popcorn( "#video" );

should be:

var popcorn = Popcorn( "#video" );

also 
       popcorn.parseJSON( "data/data.json", function() {
              alert( "JSON Parsed Successfully" );
           });
should be wrapped within DOMContentLoaded event .

We had a discussion over this issue here http://webmademovies.lighthouseapp.com/projects/63272/tickets/1406-httppopcornjsorgpopcorn-docsparsersjson20parser-sample-code-has-bugs
So I am making a pull request with changes.
