### PR TITLE
Fix typo in MediaEvents#paused() not --> no

### DIFF
--- a/media-methods/_posts/2012-12-12-paused.md
+++ b/media-methods/_posts/2012-12-12-paused.md
@@ -5,7 +5,7 @@ title: paused
 
 ## Purpose ##
 
-`paused()` is a Popcorn instance media method that informs the user whether or not the video is currently paused. It takes not arugements.
+`paused()` is a Popcorn instance media method that informs the user whether or not the video is currently paused. It takes no arugements.
 
 returns - boolean value ( true/false )
 


### PR DESCRIPTION
It takes **not** arguments --> It takes **no** arguments

Noticed it today while browsing the docs. Thanks for popcorn.js - I have a hell lot of fun working with it :-)
