### PR TITLE
Makes video play on DOMContentLoaded

### DIFF
--- a/getting-started/_posts/2012-12-12-users.md
+++ b/getting-started/_posts/2012-12-12-users.md
@@ -66,6 +66,8 @@ Next, you will need to write a few lines of JavaScript to create your Popcorn in
             target: "footnote",
             text: "Pop!"
           });
+          
+          popcorn.play();
 
         }, false );
       </script>


### PR DESCRIPTION
After you finish following the getting started page, the page appears broken on load since nothing apparent happens. By having the video automatically play, it’s more apparent that it works.
